### PR TITLE
Fixed for enable on case filesystem

### DIFF
--- a/libraries/WS2812/Seeed_ws2812.cpp
+++ b/libraries/WS2812/Seeed_ws2812.cpp
@@ -30,7 +30,7 @@
  */
 
 #include "Seeed_ws2812.h"
-#include <arduino.h>
+#include <Arduino.h>
 
 #define STM32F40xx
 

--- a/libraries/WS2812/Seeed_ws2812.h
+++ b/libraries/WS2812/Seeed_ws2812.h
@@ -32,7 +32,7 @@
 #ifndef SEEED_WS2812_h
 #define SEEED_WS2812_h
 
-#include <arduino.h>
+#include <Arduino.h>
 #include <stdlib.h>
 
 class WS2812 {


### PR DESCRIPTION
In case of compile on case enabling file system, failed.
Due to `#include` point to `arduino.h`.  Correctly it is `Arduino.h`.

Error message on Ubuntu 18.04 (Sorry, I'm Japanese...);

```
Arduino：1.8.5 (Linux), ボード："Wio Tracker LTE"

In file included from /home/wio/Arduino/libraries/Wio_LTE_for_Arduino/WioLTEforArduino.h:5:0,
                 from /home/wio/Arduino/libraries/Wio_LTE_for_Arduino/examples/basic/LedSetRGB/LedSetRGB.ino:1:
/home/wio/.arduino15/packages/Seeeduino/hardware/Seeed_STM32F4/1.2.2/libraries/WS2812/Seeed_ws2812.h:35:21: fatal error: arduino.h: No such file or directory
 #include <arduino.h>
                     ^
compilation terminated.
exit status 1
ボードWio Tracker LTEに対するコンパイル時にエラーが発生しました。
```
