### PR TITLE
Increase USART buffer to avoid overruns

### DIFF
--- a/cores/arduino/libmaple/usart.h
+++ b/cores/arduino/libmaple/usart.h
@@ -235,11 +235,11 @@ typedef struct usart_reg_map {
  */
 
 #ifndef USART_RX_BUF_SIZE
-#define USART_RX_BUF_SIZE               256
+#define USART_RX_BUF_SIZE               1280
 #endif
 
 #ifndef USART_TX_BUF_SIZE
-#define USART_TX_BUF_SIZE               256
+#define USART_TX_BUF_SIZE               1280
 #endif
 
 /** USART device type */


### PR DESCRIPTION
USART buffer of 256 causes DTLS handshakes to fail.  Extending RX and SX buffer to a size that accomodates a 512 byte binary buffer when talking to u-blox with DTLS overhead.