### PR TITLE
Current blocking option will block running software indefinitely if the serial buffer is exhausted while the device is not connected.

### DIFF
--- a/cores/arduino/libmaple/usbF4/usb.c
+++ b/cores/arduino/libmaple/usbF4/usb.c
@@ -51,6 +51,10 @@ void usbEnableBlockingTx(void) {
 	VCP_SetUSBTxBlocking(1);
 }
 
+void usbEnableSmartBlockingTx(void) {
+	VCP_SetUSBTxBlocking(2);
+}
+
 void usbDisableBlockingTx(void) {
 	VCP_SetUSBTxBlocking(0);
 }

--- a/cores/arduino/libmaple/usbF4/usb.h
+++ b/cores/arduino/libmaple/usbF4/usb.h
@@ -37,6 +37,7 @@ uint8_t usbIsConnected(void);
 uint8_t usbIsConfigured(void);
 uint16_t usbGetPending(void);
 void usbEnableBlockingTx(void);
+void usbEnableSmartBlockingTx(void);
 void usbDisableBlockingTx(void);
 
 

--- a/cores/arduino/usb_serial.cpp
+++ b/cores/arduino/usb_serial.cpp
@@ -145,6 +145,10 @@ void USBSerial::enableBlockingTx(void) {
 	usbEnableBlockingTx();
 }
 
+void USBSerial::enableSmartBlockingTx(void) {
+	usbEnableSmartBlockingTx();
+}
+
 void USBSerial::disableBlockingTx(void) {
 	usbDisableBlockingTx();
 }

--- a/cores/arduino/usb_serial.h
+++ b/cores/arduino/usb_serial.h
@@ -61,6 +61,7 @@ public:
     uint8 pending();
 
     void enableBlockingTx(void);
+    void enableSmartBlockingTx(void);
     void disableBlockingTx(void);
 };
 


### PR DESCRIPTION
This patch adds a new blocking mode ‘SmartBlocking’.  This allows blocking to be set for consistent logging output while connected to the serial port but also allows for the device to timeout the blocking if no serial port is connected allowing both for consistent serial output when connected as well as disconnected use.

New mode was added instead of modifying the existing blocking to avoid breaking users who may be relying on the previous behavior.

Initial timeout selected is 10 seconds.